### PR TITLE
Give a correct name to the merge export file 

### DIFF
--- a/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorController.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorController.java
@@ -67,12 +67,13 @@ public class MergeOrchestratorController {
     @ApiResponses(value = {@ApiResponse(code = 200, message = "The export merge for process")})
     public ResponseEntity<byte[]> exportNetwork(@ApiParam(value = "Process name") @PathVariable("process") String process,
                                                 @ApiParam(value = "Process date") @PathVariable("date") String date,
-                                                @ApiParam(value = "Export format")@PathVariable("format") String format) {
+                                                @ApiParam(value = "Export format")@PathVariable("format") String format,
+                                                @RequestParam(value = "timeZoneOffset", required = false) String timeZoneOffset) {
         LOGGER.debug("Exporting merge for process {} : {}", process, date);
         String decodedDate = URLDecoder.decode(date, StandardCharsets.UTF_8);
         ZonedDateTime dateTime = ZonedDateTime.parse(decodedDate);
 
-        ExportNetworkInfos exportedMergeInfo = mergeOrchestratorService.exportMerge(process, dateTime, format);
+        ExportNetworkInfos exportedMergeInfo = mergeOrchestratorService.exportMerge(process, dateTime, format, timeZoneOffset);
 
         HttpHeaders header = new HttpHeaders();
         header.setContentDisposition(ContentDisposition.builder("attachment").filename(exportedMergeInfo.getNetworkName(), StandardCharsets.UTF_8).build());

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorController.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorController.java
@@ -7,6 +7,7 @@
 package org.gridsuite.merge.orchestrator.server;
 
 import io.swagger.annotations.*;
+import org.gridsuite.merge.orchestrator.server.dto.ExportNetworkInfos;
 import org.gridsuite.merge.orchestrator.server.dto.Merge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,11 +19,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -68,19 +67,16 @@ public class MergeOrchestratorController {
     @ApiResponses(value = {@ApiResponse(code = 200, message = "The export merge for process")})
     public ResponseEntity<byte[]> exportNetwork(@ApiParam(value = "Process name") @PathVariable("process") String process,
                                                 @ApiParam(value = "Process date") @PathVariable("date") String date,
-                                                @ApiParam(value = "Export format")@PathVariable("format") String format) throws IOException {
+                                                @ApiParam(value = "Export format")@PathVariable("format") String format) {
         LOGGER.debug("Exporting merge for process {} : {}", process, date);
-
         String decodedDate = URLDecoder.decode(date, StandardCharsets.UTF_8);
         ZonedDateTime dateTime = ZonedDateTime.parse(decodedDate);
-        byte[] exportedMerge = mergeOrchestratorService.exportMerge(process, dateTime, format);
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
-        String filename = process + "_" + dateTime.format(formatter);
+        ExportNetworkInfos exportedMergeInfo = mergeOrchestratorService.exportMerge(process, dateTime, format);
 
         HttpHeaders header = new HttpHeaders();
-        header.setContentDisposition(ContentDisposition.builder("attachment").filename(filename, StandardCharsets.UTF_8).build());
-        return ResponseEntity.ok().headers(header).contentType(MediaType.APPLICATION_OCTET_STREAM).body(exportedMerge);
+        header.setContentDisposition(ContentDisposition.builder("attachment").filename(exportedMergeInfo.getNetworkName(), StandardCharsets.UTF_8).build());
+        return ResponseEntity.ok().headers(header).contentType(MediaType.APPLICATION_OCTET_STREAM).body(exportedMergeInfo.getNetworkData());
     }
 
 }

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorService.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorService.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -216,9 +217,11 @@ public class MergeOrchestratorService {
                 .collect(Collectors.toList());
     }
 
-    byte[] exportMerge(String process, ZonedDateTime processDate, String format) {
+    ExportNetworkInfos exportMerge(String process, ZonedDateTime processDate, String format) {
         List<UUID> networksUuids =  findNetworkUuidsOfValidatedIgms(processDate, process);
-        return networkConversionService.exportMerge(networksUuids, format);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
+        String baseFileName = process + "_" + processDate.format(formatter);
+        return networkConversionService.exportMerge(networksUuids, format, baseFileName);
     }
 
     private static Igm toIgm(IgmEntity entity) {

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorService.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorService.java
@@ -217,10 +217,11 @@ public class MergeOrchestratorService {
                 .collect(Collectors.toList());
     }
 
-    ExportNetworkInfos exportMerge(String process, ZonedDateTime processDate, String format) {
+    ExportNetworkInfos exportMerge(String process, ZonedDateTime processDate, String format, String timeZoneOffset) {
         List<UUID> networksUuids =  findNetworkUuidsOfValidatedIgms(processDate, process);
+        LocalDateTime requesterDateTime = timeZoneOffset != null ? LocalDateTime.ofInstant(processDate.toInstant(), ZoneOffset.ofHours(Integer.parseInt(timeZoneOffset) / 60)) : processDate.toLocalDateTime();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
-        String baseFileName = process + "_" + processDate.format(formatter);
+        String baseFileName = process + "_" + requesterDateTime.format(formatter);
         return networkConversionService.exportMerge(networksUuids, format, baseFileName);
     }
 

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/NetworkConversionService.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/NetworkConversionService.java
@@ -20,6 +20,7 @@ import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -52,10 +53,10 @@ public class NetworkConversionService {
         String uri = uriBuilder.build().toUriString();
 
         ResponseEntity<byte[]> responseEntity = networkConversionServerRest.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY, new ParameterizedTypeReference<>() { }, networksIds.get(0).toString(), format);
-        String exportedFileName = responseEntity.getHeaders().getContentDisposition().getFilename();
         String exportedFileExtension;
         try {
-            exportedFileExtension = exportedFileName.substring(exportedFileName.lastIndexOf("."));
+            String exportedFileName = responseEntity.getHeaders().getContentDisposition().getFilename();
+            exportedFileExtension = Objects.nonNull(exportedFileName) ? exportedFileName.substring(exportedFileName.lastIndexOf(".")) : ".unknown";
         } catch (IndexOutOfBoundsException e) {
             exportedFileExtension = ".unknown";
         }

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/dto/ExportNetworkInfos.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/dto/ExportNetworkInfos.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.merge.orchestrator.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ExportNetworkInfos {
+
+    private String networkName;
+
+    private byte[] networkData;
+
+}

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/dto/ExportNetworkInfos.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/dto/ExportNetworkInfos.java
@@ -8,14 +8,12 @@ package org.gridsuite.merge.orchestrator.server.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 public class ExportNetworkInfos {
 

--- a/src/test/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorControllerTest.java
+++ b/src/test/java/org/gridsuite/merge/orchestrator/server/MergeOrchestratorControllerTest.java
@@ -6,6 +6,8 @@
  */
 package org.gridsuite.merge.orchestrator.server;
 
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import org.gridsuite.merge.orchestrator.server.dto.ExportNetworkInfos;
 import org.gridsuite.merge.orchestrator.server.dto.IgmStatus;
 import org.gridsuite.merge.orchestrator.server.dto.MergeStatus;
 import org.gridsuite.merge.orchestrator.server.repositories.*;
@@ -27,9 +29,12 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static com.powsybl.network.store.model.NetworkStoreApi.VERSION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -163,6 +168,8 @@ public class MergeOrchestratorControllerTest extends AbstractEmbeddedCassandraSe
         igmRepository.insert(new IgmEntity(new IgmEntityKey("swe", dateTime3.toLocalDateTime(), "ES"), IgmStatus.VALIDATION_SUCCEED.name(), UUID_NETWORK_MERGE_2));
         igmRepository.insert(new IgmEntity(new IgmEntityKey("swe", dateTime3.toLocalDateTime(), "PT"), IgmStatus.VALIDATION_SUCCEED.name(), UUID_NETWORK_MERGE_3));
         String processDate = URLEncoder.encode(formatter.format(dateTime3), StandardCharsets.UTF_8);
+        given(networkConversionService.exportMerge(any(List.class), any(String.class), any(String.class)))
+                .willReturn(new ExportNetworkInfos("testFile.xiidm", ByteArrayBuilder.NO_BYTES));
         mvc.perform(get("/" + VERSION + "/swe/" + processDate + "/export/XIIDM")
                 .contentType(APPLICATION_OCTET_STREAM))
                 .andExpect(status().isOk())

--- a/src/test/java/org/gridsuite/merge/orchestrator/server/NetworkConversionServiceTest.java
+++ b/src/test/java/org/gridsuite/merge/orchestrator/server/NetworkConversionServiceTest.java
@@ -6,16 +6,17 @@
  */
 package org.gridsuite.merge.orchestrator.server;
 
+import org.gridsuite.merge.orchestrator.server.dto.ExportNetworkInfos;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -45,14 +46,17 @@ public class NetworkConversionServiceTest {
 
     @Test
     public void test() {
+        HttpHeaders header = new HttpHeaders();
+        header.setContentDisposition(ContentDisposition.builder("attachment").filename("test_file.xiidm", StandardCharsets.UTF_8).build());
         when(networkConversionServerRest.exchange(anyString(),
                 eq(HttpMethod.GET),
                 any(),
                 any(ParameterizedTypeReference.class),
                 eq(randomUuid1.toString()),
                 eq("XIIDM")))
-                .thenReturn(ResponseEntity.ok(response));
-        byte[] res = networkConversionService.exportMerge(Arrays.asList(randomUuid1, randomUuid2, randomUuid3), "XIIDM");
-        assertEquals(response, res);
+                .thenReturn(new ResponseEntity(response, header, HttpStatus.OK));
+        ExportNetworkInfos res = networkConversionService.exportMerge(Arrays.asList(randomUuid1, randomUuid2, randomUuid3), "XIIDM", "merge_name");
+        assertEquals(response, res.getNetworkData());
+        assertEquals("merge_name.xiidm", res.getNetworkName());
     }
 }


### PR DESCRIPTION
File extension is given by the network conversion export service, depending on the export format.
The merge export file default name contains the date of merge as expected by the user (i.e. with the correct time zone).
