### PR TITLE
Workaround compilation crash with jdk11 < 11.0.8

### DIFF
--- a/src/main/java/org/gridsuite/merge/orchestrator/server/CaseFetcherService.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/CaseFetcherService.java
@@ -89,7 +89,7 @@ public class CaseFetcherService {
                 .queryParam("q", getSearchQuery(tsos, dateTime, format, businessProcess)).build().toUriString();
 
         try {
-            ResponseEntity<List<Map<String, String>>> responseEntity = caseServerRest.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY, new ParameterizedTypeReference<>() { });
+            ResponseEntity<List<Map<String, String>>> responseEntity = caseServerRest.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY, new ParameterizedTypeReference<List<Map<String, String>>>() { });
             List<Map<String, String>> body = responseEntity.getBody();
             if (body != null) {
                 return body.stream().map(c -> new CaseInfos(c.get("name"),

--- a/src/main/java/org/gridsuite/merge/orchestrator/server/NetworkConversionService.java
+++ b/src/main/java/org/gridsuite/merge/orchestrator/server/NetworkConversionService.java
@@ -52,7 +52,7 @@ public class NetworkConversionService {
         }
         String uri = uriBuilder.build().toUriString();
 
-        ResponseEntity<byte[]> responseEntity = networkConversionServerRest.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY, new ParameterizedTypeReference<>() { }, networksIds.get(0).toString(), format);
+        ResponseEntity<byte[]> responseEntity = networkConversionServerRest.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY, new ParameterizedTypeReference<byte[]>() { }, networksIds.get(0).toString(), format);
         String exportedFileExtension;
         try {
             String exportedFileName = responseEntity.getHeaders().getContentDisposition().getFilename();


### PR DESCRIPTION
See
https://stackoverflow.com/questions/54775253/jdk-11-0-2-compilation-fails-with-javac-npe-on-anonymous-parameterized-class-typ
https://bugs.openjdk.java.net/browse/JDK-8212586

Error message from the command line:
        compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.5, {1}, {2}, {3}, {4}, {5}, {6}, {7}
        java.lang.NullPointerException
                at jdk.compiler/com.sun.tools.javac.comp.Flow$FlowAnalyzer.visitApply(Flow.java:1235)
                at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1634)
                at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
                ...
