### PR TITLE
Fix non reproducible tests depending on the order

### DIFF
--- a/src/test/java/org/gridsuite/merge/orchestrator/server/ProcessConfigControllerTest.java
+++ b/src/test/java/org/gridsuite/merge/orchestrator/server/ProcessConfigControllerTest.java
@@ -69,6 +69,7 @@ public class ProcessConfigControllerTest {
 
     @Before
     public void setUp() {
+        processConfigRepository.deleteAll();
         MockitoAnnotations.initMocks(this);
         tsos.clear();
         tsos.add("FR");


### PR DESCRIPTION
ProcessConfigControllerTest assumes the db is empty,
but MergeOrchestratorControllerTest leaves it with
FRES_2D_UUID (21111111-f60e-4766-bc5c-8f312c1984e4)

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>